### PR TITLE
Rename LONG_MAX_VALUE to MAX_CHAT_ORDER_OFFSET

### DIFF
--- a/src/constants/number.ts
+++ b/src/constants/number.ts
@@ -1,1 +1,0 @@
-export const LONG_MAX_VALUE = "9223372036854775807";

--- a/src/store/chats/saga.ts
+++ b/src/store/chats/saga.ts
@@ -1,8 +1,14 @@
 import { all, put, takeEvery } from "redux-saga/effects";
 import { getType } from "typesafe-actions";
-import { LONG_MAX_VALUE } from "../../constants/number";
 import { asyncSendMessage } from "../telegram/saga";
 import * as actions from "./actions";
+
+/**
+ * Represents maximum possible value of 64bit integer.
+ * Used for getting most recent chats.
+ * @see https://core.telegram.org/tdlib/getting-started#getting-the-list-of-chats
+ */
+const MAX_CHAT_ORDER_OFFSET = "9223372036854775807";
 
 function* getChats(action: ReturnType<typeof actions.GetChatsAction>) {
   const { params } = action.payload;
@@ -11,7 +17,7 @@ function* getChats(action: ReturnType<typeof actions.GetChatsAction>) {
     const { payload } = yield asyncSendMessage({
       "@type": "getChats",
       limit: params.limit,
-      offset_order: params.offsetOrder || LONG_MAX_VALUE,
+      offset_order: params.offsetOrder || MAX_CHAT_ORDER_OFFSET,
       offset_chat_id: params.offsetChatId || 0
     });
 


### PR DESCRIPTION
LONG_MAX_VALUE was not meaningful and was used only once in the code.

MAX_CHAT_ORDER_OFFSET gives more value in order to be used in `getChats` function.